### PR TITLE
udpate styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,7 +25,7 @@ ul.list-adaptive li::marker {
     }
 
     .p-header {
-        @apply text-gray-600 dark:text-gray-100 text-left text-lg mb-12;
+        @apply text-gray-600 dark:text-gray-100 text-left text-lg;
     }
 
     .p-job-summary {


### PR DESCRIPTION
This pull request includes a minor change to the `src/index.css` file. The change removes an unnecessary margin-bottom property from the `.p-header` class.

* [`src/index.css`](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL28-R28): Removed the `mb-12` property from the `.p-header` class to eliminate extra bottom margin.